### PR TITLE
PM-4211: merge M2M member scopes across auth layers

### DIFF
--- a/src/shared/services/permission.service.spec.ts
+++ b/src/shared/services/permission.service.spec.ts
@@ -488,6 +488,27 @@ describe('PermissionService', () => {
     expect(allowed).toBe(true);
   });
 
+  it.each([
+    Permission.CREATE_PROJECT_MEMBER_NOT_OWN,
+    Permission.UPDATE_PROJECT_MEMBER_NON_CUSTOMER,
+    Permission.DELETE_PROJECT_MEMBER_TOPCODER,
+  ])(
+    'allows %s when raw M2M token scopes are broader than user.scopes',
+    (permission) => {
+      const allowed = service.hasNamedPermission(permission, {
+        scopes: [Scope.PROJECTS_READ],
+        isMachine: false,
+        tokenPayload: {
+          gty: 'client-credentials',
+          scope: `${Scope.PROJECTS_READ} ${Scope.PROJECT_MEMBERS_WRITE}`,
+          sub: 'svc-projects@clients',
+        },
+      });
+
+      expect(allowed).toBe(true);
+    },
+  );
+
   it('allows reading other users project invites for machine token with invite read scope', () => {
     const allowed = service.hasNamedPermission(
       Permission.READ_PROJECT_INVITE_NOT_OWN,

--- a/src/shared/services/permission.service.ts
+++ b/src/shared/services/permission.service.ts
@@ -633,6 +633,11 @@ export class PermissionService {
    * Resolves machine-token status and effective scopes from the normalized user
    * and the raw token payload so guard and permission checks stay aligned.
    *
+   * Merges both scope sources because upstream auth middleware can populate
+   * `user.scopes` differently from the raw token payload used by
+   * `TokenRolesGuard`. Keeping the union here avoids false 403s when one source
+   * is stale or incomplete but the other still carries the granted M2M scopes.
+   *
    * @param user authenticated JWT user context
    * @returns machine classification and the scopes to evaluate
    */
@@ -643,13 +648,18 @@ export class PermissionService {
     const payloadMachineContext = this.m2mService.validateMachineToken(
       user.tokenPayload,
     );
+    const userScopes = Array.isArray(user.scopes)
+      ? user.scopes
+          .map((scope) => String(scope).trim())
+          .filter((scope) => scope.length > 0)
+      : [];
+    const mergedScopes = Array.from(
+      new Set([...userScopes, ...payloadMachineContext.scopes]),
+    );
 
     return {
       isMachine: Boolean(user.isMachine || payloadMachineContext.isMachine),
-      scopes:
-        Array.isArray(user.scopes) && user.scopes.length > 0
-          ? user.scopes
-          : payloadMachineContext.scopes,
+      scopes: mergedScopes,
     };
   }
 


### PR DESCRIPTION
What was broken
M2M POST, PATCH, and DELETE requests for project members could still return 403 when the raw token payload carried project-member write scope but the normalized user scope list did not fully match it.

Root cause (if identifiable)
PermissionService preferred user.scopes over the raw token payload, while TokenRolesGuard evaluates the raw token payload directly. When those two scope sources drifted, the write routes could pass the auth guard and still fail inside project-member permission checks.

What was changed
PermissionService now merges scopes from user.scopes and the raw token payload before evaluating named permissions, so M2M project-member write checks use the same effective grants across the guard and service layers.
Added a focused regression for create, update, and delete project-member permissions when tokenPayload.scope is broader than user.scopes.

Any added/updated tests
Updated src/shared/services/permission.service.spec.ts with create, update, and delete project-member M2M regression coverage for mismatched scope sources.
Validation run: pnpm lint, pnpm build, pnpm test -- src/shared/services/permission.service.spec.ts, and pnpm test:e2e -- --runInBand test/project-member.e2e-spec.ts passed.
pnpm test still fails in unrelated metadata event-publishing specs already failing on the current dev baseline.
