### PR TITLE
PM-4211: cover Auth0 M2M member token shape

### DIFF
--- a/src/shared/modules/global/jwt.service.spec.ts
+++ b/src/shared/modules/global/jwt.service.spec.ts
@@ -1,4 +1,5 @@
 import * as jwt from 'jsonwebtoken';
+import { Scope } from 'src/shared/enums/scopes.enum';
 import { JwtService } from './jwt.service';
 
 function signToken(payload: Record<string, unknown>): string {
@@ -42,6 +43,33 @@ describe('JwtService', () => {
     const user = await service.validateToken(token);
 
     expect(user.userId).toBe('auth0|abcd');
+  });
+
+  it('extracts Auth0 client-credentials scopes for machine subjects', async () => {
+    const token = signToken({
+      sub: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+      azp: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8',
+      gty: 'client-credentials',
+      scope: `${Scope.PROJECTS_READ} ${Scope.PROJECT_MEMBERS_WRITE}`,
+    });
+
+    const user = await service.validateToken(token);
+
+    expect(user).toEqual(
+      expect.objectContaining({
+        userId: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+        isMachine: true,
+        scopes: expect.arrayContaining([
+          Scope.PROJECTS_READ,
+          Scope.PROJECT_MEMBERS_WRITE,
+        ]),
+        tokenPayload: expect.objectContaining({
+          sub: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+          azp: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8',
+          gty: 'client-credentials',
+        }),
+      }),
+    );
   });
 
   it('extracts lower-cased email from namespaced email claim', async () => {

--- a/test/project-member.e2e-spec.ts
+++ b/test/project-member.e2e-spec.ts
@@ -38,6 +38,20 @@ const tokenUsers: Record<string, JwtUser> = {
   },
 };
 
+function createAuth0MachineMemberWriteUser(): JwtUser {
+  return {
+    userId: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+    scopes: [Scope.PROJECTS_READ],
+    isMachine: true,
+    tokenPayload: {
+      sub: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+      azp: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8',
+      gty: 'client-credentials',
+      scope: `${Scope.PROJECTS_READ} ${Scope.PROJECT_MEMBERS_WRITE}`,
+    },
+  };
+}
+
 @Controller('/projects/project-member-test')
 class ProjectMemberTestController {
   @Get('/health')
@@ -301,6 +315,86 @@ describe('Project Member endpoints (e2e)', () => {
       expect.objectContaining({
         scopes: [Scope.PROJECT_MEMBERS_WRITE],
         isMachine: true,
+      }),
+    );
+  });
+
+  it('creates members for Auth0-shaped m2m token when tokenPayload scope is broader than user.scopes', async () => {
+    (jwtServiceMock.validateToken as jest.Mock).mockResolvedValueOnce(
+      createAuth0MachineMemberWriteUser(),
+    );
+
+    await request(app.getHttpServer())
+      .post('/v6/projects/1001/members')
+      .set('Authorization', 'Bearer m2m-member-write-auth0-shape')
+      .send({ userId: '101125', role: 'observer' })
+      .expect(201);
+
+    expect(projectMemberServiceMock.addMember).toHaveBeenCalledWith(
+      '1001',
+      expect.objectContaining({ userId: '101125', role: 'observer' }),
+      expect.objectContaining({
+        userId: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+        scopes: [Scope.PROJECTS_READ],
+        isMachine: true,
+        tokenPayload: expect.objectContaining({
+          gty: 'client-credentials',
+          scope: `${Scope.PROJECTS_READ} ${Scope.PROJECT_MEMBERS_WRITE}`,
+        }),
+      }),
+      undefined,
+    );
+  });
+
+  it('updates members for Auth0-shaped m2m token when tokenPayload scope is broader than user.scopes', async () => {
+    (jwtServiceMock.validateToken as jest.Mock).mockResolvedValueOnce(
+      createAuth0MachineMemberWriteUser(),
+    );
+
+    await request(app.getHttpServer())
+      .patch('/v6/projects/1001/members/11')
+      .set('Authorization', 'Bearer m2m-member-write-auth0-shape')
+      .send({ role: 'observer' })
+      .expect(200);
+
+    expect(projectMemberServiceMock.updateMember).toHaveBeenCalledWith(
+      '1001',
+      '11',
+      expect.objectContaining({ role: 'observer' }),
+      expect.objectContaining({
+        userId: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+        scopes: [Scope.PROJECTS_READ],
+        isMachine: true,
+        tokenPayload: expect.objectContaining({
+          gty: 'client-credentials',
+          scope: `${Scope.PROJECTS_READ} ${Scope.PROJECT_MEMBERS_WRITE}`,
+        }),
+      }),
+      undefined,
+    );
+  });
+
+  it('deletes members for Auth0-shaped m2m token when tokenPayload scope is broader than user.scopes', async () => {
+    (jwtServiceMock.validateToken as jest.Mock).mockResolvedValueOnce(
+      createAuth0MachineMemberWriteUser(),
+    );
+
+    await request(app.getHttpServer())
+      .delete('/v6/projects/1001/members/11')
+      .set('Authorization', 'Bearer m2m-member-write-auth0-shape')
+      .expect(204);
+
+    expect(projectMemberServiceMock.deleteMember).toHaveBeenCalledWith(
+      '1001',
+      '11',
+      expect.objectContaining({
+        userId: 'VYWpLOVcDTMvUUlZmNaqhwxjqXWn0qu8@clients',
+        scopes: [Scope.PROJECTS_READ],
+        isMachine: true,
+        tokenPayload: expect.objectContaining({
+          gty: 'client-credentials',
+          scope: `${Scope.PROJECTS_READ} ${Scope.PROJECT_MEMBERS_WRITE}`,
+        }),
       }),
     );
   });


### PR DESCRIPTION
What was broken
The earlier PM-4211 runtime fix handled M2M project-member writes, but the exact Auth0 client-credentials token shape from QA was still not covered by automated regression. That left POST /v6/projects/{projectId}/members, PATCH /v6/projects/{projectId}/members/{id}, and DELETE /v6/projects/{projectId}/members/{id} vulnerable to future regressions without a failing test.

Root cause (if identifiable)
The existing route e2e coverage mocked a simplified machine user, and JwtService coverage did not assert the non-numeric @clients subject plus project-member write scope combination from the QA token.

What was changed
Added JwtService coverage for an Auth0 client-credentials subject carrying project-member write scope.
Added guarded project-member POST, PATCH, and DELETE regression coverage for an Auth0-shaped M2M principal whose raw token payload is broader than user.scopes.

Any added/updated tests
Updated src/shared/modules/global/jwt.service.spec.ts.
Updated test/project-member.e2e-spec.ts.
Validation run: pnpm test -- src/shared/modules/global/jwt.service.spec.ts; pnpm test:e2e -- --runInBand test/project-member.e2e-spec.ts; pnpm test -- src/shared/services/permission.service.spec.ts; pnpm test -- src/api/project-member/project-member.service.spec.ts; pnpm lint; pnpm build.
pnpm test still fails in unrelated metadata event-publishing specs on the current dev baseline.
