### PR TITLE
PM-4847: scope PM/TM project access to memberships

### DIFF
--- a/src/api/project/project.service.spec.ts
+++ b/src/api/project/project.service.spec.ts
@@ -65,6 +65,16 @@ describe('ProjectService', () => {
     prismaMock.$queryRaw.mockResolvedValue([]);
     memberServiceMock.getMemberDetailsByUserIds.mockResolvedValue([]);
     memberServiceMock.getUserRoles.mockResolvedValue([]);
+    permissionServiceMock.hasIntersection.mockImplementation(
+      (userRoles: string[] = [], allowedRoles: string[] = []) =>
+        userRoles.some((userRole) =>
+          allowedRoles.some(
+            (allowedRole) =>
+              String(userRole).trim().toLowerCase() ===
+              String(allowedRole).trim().toLowerCase(),
+          ),
+        ),
+    );
     service = new ProjectService(
       prismaMock as any,
       permissionServiceMock as unknown as PermissionService,
@@ -259,6 +269,66 @@ describe('ProjectService', () => {
       'JMGasper+devtest140@gmail.com',
     );
   });
+
+  it.each([
+    ['project manager', UserRole.PROJECT_MANAGER],
+    ['talent manager', UserRole.TALENT_MANAGER],
+  ])(
+    'scopes %s project listings to project membership',
+    async (_label: string, role: UserRole) => {
+      permissionServiceMock.hasNamedPermission.mockImplementation(
+        (permission: Permission): boolean =>
+          permission === Permission.READ_PROJECT_ANY ||
+          permission === Permission.READ_PROJECT_MEMBER,
+      );
+      permissionServiceMock.hasIntersection.mockReturnValue(false);
+
+      prismaMock.project.count.mockResolvedValue(0);
+      prismaMock.project.findMany.mockResolvedValue([]);
+
+      await service.listProjects(
+        {
+          page: 1,
+          perPage: 20,
+        },
+        {
+          userId: '999',
+          roles: [role],
+          isMachine: false,
+        },
+      );
+
+      expect(prismaMock.project.count).toHaveBeenCalledWith({
+        where: {
+          deletedAt: null,
+          AND: [
+            {
+              OR: [
+                {
+                  members: {
+                    some: {
+                      userId: BigInt(999),
+                      deletedAt: null,
+                    },
+                  },
+                },
+                {
+                  invites: {
+                    some: {
+                      userId: BigInt(999),
+                      status: 'pending',
+                      deletedAt: null,
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      });
+    },
+  );
+
   it('does not load relation payloads by default in project listing', async () => {
     permissionServiceMock.hasNamedPermission.mockImplementation(
       (permission: Permission): boolean =>
@@ -450,6 +520,67 @@ describe('ProjectService', () => {
       }),
     ).rejects.toBeInstanceOf(NotFoundException);
   });
+
+  it.each([
+    ['project manager', UserRole.PROJECT_MANAGER],
+    ['talent manager', UserRole.TALENT_MANAGER],
+  ])(
+    'rejects direct project access for %s callers who are not on the project',
+    async (_label: string, role: UserRole) => {
+      const now = new Date();
+
+      prismaMock.project.findFirst.mockResolvedValue({
+        id: BigInt(1001),
+        name: 'Demo',
+        description: null,
+        type: 'app',
+        status: 'active',
+        billingAccountId: null,
+        directProjectId: null,
+        estimatedPrice: null,
+        actualPrice: null,
+        terms: [],
+        groups: [],
+        external: null,
+        bookmarks: null,
+        utm: null,
+        details: null,
+        challengeEligibility: null,
+        cancelReason: null,
+        templateId: null,
+        version: 'v3',
+        lastActivityAt: now,
+        lastActivityUserId: '100',
+        createdAt: now,
+        updatedAt: now,
+        createdBy: 100,
+        updatedBy: 100,
+        members: [
+          {
+            userId: BigInt(100),
+            role: 'manager',
+            deletedAt: null,
+          },
+        ],
+        invites: [],
+        attachments: [],
+      });
+      permissionServiceMock.hasNamedPermission.mockImplementation(
+        (permission: Permission): boolean =>
+          permission === Permission.VIEW_PROJECT ||
+          permission === Permission.READ_PROJECT_ANY,
+      );
+      permissionServiceMock.hasIntersection.mockReturnValue(false);
+
+      await expect(
+        service.getProject('1001', undefined, {
+          userId: '999',
+          roles: [role],
+          isMachine: false,
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    },
+  );
 
   it('lists billing accounts for project id', async () => {
     billingAccountServiceMock.getBillingAccountsForProject.mockResolvedValue([

--- a/src/api/project/project.service.ts
+++ b/src/api/project/project.service.ts
@@ -137,12 +137,13 @@ export class ProjectService {
     const perPage = criteria.perPage || 20;
     const skip = (page - 1) * perPage;
 
-    const isAdmin = this.permissionService.hasNamedPermission(
-      Permission.READ_PROJECT_ANY,
-      user,
-    );
+    const hasGlobalProjectReadAccess = this.hasGlobalProjectReadAccess(user);
 
-    const where = buildProjectWhereClause(criteria, user, isAdmin);
+    const where = buildProjectWhereClause(
+      criteria,
+      user,
+      hasGlobalProjectReadAccess,
+    );
     const requestedFields = this.resolveListFields(criteria.fields);
     const includeFields = this.resolveListIncludeFields(requestedFields);
     const include = buildProjectIncludeClause(includeFields);
@@ -171,7 +172,7 @@ export class ProjectService {
       const filteredProject = this.filterProjectRelations(
         project,
         user,
-        isAdmin,
+        hasGlobalProjectReadAccess,
       );
       const projectWithRequestedFields = this.filterProjectFields(
         filteredProject,
@@ -200,14 +201,17 @@ export class ProjectService {
    *
    * Members and invites are always loaded for permission evaluation regardless
    * of requested `fields`, then relation visibility is filtered by caller
-   * permissions before response serialization.
+   * permissions before response serialization. Human PM/TM-style callers must
+   * still be a project member or pending invitee; only admins, legacy manager
+   * roles, and authorized machine principals bypass membership scoping.
    *
    * @param projectId Project id path parameter.
    * @param fieldsParam Optional CSV list of relation fields.
    * @param user Authenticated caller context.
    * @returns Project response DTO.
    * @throws NotFoundException When the project does not exist.
-   * @throws ForbiddenException When caller lacks `VIEW_PROJECT`.
+   * @throws ForbiddenException When caller lacks `VIEW_PROJECT` or does not
+   * have member/invite visibility for the requested project.
    */
   async getProject(
     projectId: string,
@@ -239,6 +243,10 @@ export class ProjectService {
     const [projectWithMemberHandles] =
       await this.enrichProjectsWithMemberHandles([project]);
     const projectWithRelations = projectWithMemberHandles || project;
+    const hasGlobalProjectReadAccess = this.hasGlobalProjectReadAccess(
+      user,
+      projectWithRelations.members || [],
+    );
 
     const canViewProject = this.permissionService.hasNamedPermission(
       Permission.VIEW_PROJECT,
@@ -254,16 +262,21 @@ export class ProjectService {
       throw new ForbiddenException('Insufficient permissions');
     }
 
-    const isAdmin = this.permissionService.hasNamedPermission(
-      Permission.READ_PROJECT_ANY,
-      user,
-      projectWithRelations.members || [],
-    );
+    if (
+      !hasGlobalProjectReadAccess &&
+      !this.hasProjectScopedVisibility(
+        user,
+        projectWithRelations.members || [],
+        projectWithRelations.invites || [],
+      )
+    ) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
 
     const filteredProject = this.filterProjectRelations(
       projectWithRelations,
       user,
-      isAdmin,
+      hasGlobalProjectReadAccess,
     );
     const projectWithRequestedFields = this.filterProjectFields(
       filteredProject,
@@ -784,14 +797,17 @@ export class ProjectService {
       await this.enrichProjectsWithMemberHandles([project]);
     const projectWithRelations = projectWithMemberHandles || project;
 
-    const isAdmin = this.permissionService.hasNamedPermission(
-      Permission.READ_PROJECT_ANY,
+    const hasGlobalProjectReadAccess = this.hasGlobalProjectReadAccess(
       user,
       projectWithRelations.members || [],
     );
 
     const response = this.toDto(
-      this.filterProjectRelations(projectWithRelations, user, isAdmin),
+      this.filterProjectRelations(
+        projectWithRelations,
+        user,
+        hasGlobalProjectReadAccess,
+      ),
     );
 
     this.publishEvent(KAFKA_TOPIC.PROJECT_UPDATED, response);
@@ -1411,6 +1427,99 @@ export class ProjectService {
     }
 
     return undefined;
+  }
+
+  /**
+   * Returns whether the caller may bypass project membership visibility checks.
+   *
+   * Human callers only retain global access for admin or legacy manager roles.
+   * Machine principals continue to rely on the named permission so scoped
+   * service tokens can read any project when authorized.
+   *
+   * @param user Authenticated caller context.
+   * @param projectMembers Optional project members for permission evaluation.
+   * @returns `true` when the caller can read projects without membership.
+   */
+  private hasGlobalProjectReadAccess(
+    user: JwtUser,
+    projectMembers: ProjectMember[] = [],
+  ): boolean {
+    if (this.isMachinePrincipal(user)) {
+      return this.permissionService.hasNamedPermission(
+        Permission.READ_PROJECT_ANY,
+        user,
+        projectMembers,
+      );
+    }
+
+    return this.permissionService.hasIntersection(user.roles || [], [
+      ...ADMIN_ROLES,
+      UserRole.MANAGER,
+      UserRole.TOPCODER_MANAGER,
+    ]);
+  }
+
+  /**
+   * Returns whether the caller can see a project through membership or invite.
+   *
+   * @param user Authenticated caller context.
+   * @param projectMembers Active project members.
+   * @param projectInvites Pending or historical project invites.
+   * @returns `true` when the caller is a member or has a pending invite.
+   */
+  private hasProjectScopedVisibility(
+    user: JwtUser,
+    projectMembers: ProjectMember[],
+    projectInvites: ProjectMemberInvite[],
+  ): boolean {
+    const parsedUserId = this.parseUserIdValue(user.userId);
+
+    if (
+      parsedUserId &&
+      projectMembers.some((member) => {
+        const parsedMemberUserId = this.parseUserIdValue(member.userId);
+
+        return Boolean(
+          parsedMemberUserId &&
+            parsedMemberUserId === parsedUserId &&
+            member.deletedAt === null,
+        );
+      })
+    ) {
+      return true;
+    }
+
+    const normalizedEmail = String(user.email || '')
+      .trim()
+      .toLowerCase();
+
+    return projectInvites.some((invite) => {
+      if (
+        invite.deletedAt !== null ||
+        String(invite.status || '').trim().toLowerCase() !== 'pending'
+      ) {
+        return false;
+      }
+
+      const parsedInviteUserId = this.parseUserIdValue(invite.userId);
+
+      if (
+        parsedUserId &&
+        parsedInviteUserId &&
+        parsedInviteUserId === parsedUserId
+      ) {
+        return true;
+      }
+
+      if (!normalizedEmail) {
+        return false;
+      }
+
+      return (
+        typeof invite.email === 'string' &&
+        invite.email.trim().toLowerCase() === normalizedEmail
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
What was broken
PM and TM users could list every project in Work Manager and open project records they were not part of.

Root cause
ProjectService treated PM/TM-style roles as global project readers when building the projects query and when resolving a project by id, so membership scoping was bypassed unless the client explicitly requested memberOnly filtering.

What was changed
Added a service-level global-read check that only bypasses membership scoping for admins, legacy manager roles, and authorized machine principals.
Applied that check to project listing, direct project fetches, and project response filtering so PM/TM callers must now be project members or pending invitees.

Any added/updated tests
Added ProjectService coverage for PM/TM project list scoping and for rejecting direct project access when the caller is not on the project.
Validated with pnpm test -- src/api/project/project.service.spec.ts, pnpm lint, and pnpm build.
The repo-wide pnpm test run still fails in unrelated metadata event-publishing specs.
