### PR TITLE
PM-2648: Support wrapped PM role lookups for application emails

### DIFF
--- a/src/shared/services/member.service.spec.ts
+++ b/src/shared/services/member.service.spec.ts
@@ -88,6 +88,65 @@ describe('MemberService', () => {
     );
   });
 
+  it('returns subjects from legacy wrapped Identity role responses', async () => {
+    httpServiceMock.get.mockImplementation(
+      (url: string, options: { params?: { filter?: string } }) => {
+        if (
+          url === 'https://identity.test/roles' &&
+          options.params?.filter === 'roleName=Project Manager'
+        ) {
+          return of({
+            data: {
+              result: {
+                content: [{ id: '201', roleName: 'Project Manager' }],
+              },
+            },
+          });
+        }
+
+        if (url === 'https://identity.test/roles/201') {
+          return of({
+            data: {
+              result: {
+                content: {
+                  subjects: [
+                    {
+                      subjectId: 5001,
+                      handle: 'pm-one',
+                      email: 'PM.One@Topcoder.com',
+                    },
+                  ],
+                },
+              },
+            },
+          });
+        }
+
+        return of({ data: {} });
+      },
+    );
+
+    const result = await service.getRoleSubjects('Project Manager');
+
+    expect(result).toEqual([
+      {
+        userId: 5001,
+        handle: 'pm-one',
+        email: 'pm.one@topcoder.com',
+      },
+    ]);
+    expect(httpServiceMock.get).toHaveBeenCalledWith(
+      'https://identity.test/roles/201',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          fields: 'subjects',
+          selector: 'subjects',
+          perPage: 200,
+        }),
+      }),
+    );
+  });
+
   it('returns empty list when role list lookup fails', async () => {
     httpServiceMock.get.mockImplementation((url: string) => {
       if (url === 'https://identity.test/roles') {

--- a/src/shared/services/member.service.ts
+++ b/src/shared/services/member.service.ts
@@ -13,13 +13,10 @@ export interface MemberRoleRecord {
 
 type RoleSubjectRecord = {
   subjectID?: string | number;
+  subjectId?: string | number;
   userId?: string | number;
   handle?: string;
   email?: string;
-};
-
-type RoleDetailResponse = {
-  subjects?: RoleSubjectRecord[];
 };
 
 /**
@@ -213,9 +210,9 @@ export class MemberService {
    * Looks up role members from Identity API by role name.
    *
    * Resolves `/roles?filter=roleName=<roleName>` and then
-   * `/roles/:id?selector=subjects&perPage=200`, returning the merged
-   * `subjects` list
-   * normalized to `MemberDetail` shape.
+   * `/roles/:id` with subject expansion, returning the merged `subjects` list
+   * normalized to `MemberDetail` shape. Supports both direct array responses
+   * and the legacy `{ result: { content } }` Identity response wrapper.
    *
    * Role-detail lookups are tolerant to partial failures; one failing role id
    * does not prevent subjects from other matching roles from being returned.
@@ -250,9 +247,9 @@ export class MemberService {
         }),
       );
 
-      const roles = Array.isArray(rolesResponse.data)
-        ? (rolesResponse.data as MemberRoleRecord[])
-        : [];
+      const roles = this.extractArrayPayload<MemberRoleRecord>(
+        rolesResponse.data,
+      );
 
       const roleIds = roles
         .filter(
@@ -276,14 +273,14 @@ export class MemberService {
                 'Content-Type': 'application/json',
               },
               params: {
+                fields: 'subjects',
                 selector: 'subjects',
                 perPage: 200,
               },
             }),
           );
 
-          const payload = roleResponse.data as RoleDetailResponse;
-          return Array.isArray(payload?.subjects) ? payload.subjects : [];
+          return this.extractRoleSubjects(roleResponse.data);
         }),
       );
 
@@ -310,7 +307,7 @@ export class MemberService {
           .trim()
           .toLowerCase();
         const subjectId = String(
-          subject.subjectID || subject.userId || '',
+          subject.subjectID || subject.subjectId || subject.userId || '',
         ).trim();
 
         const key = email || subjectId;
@@ -319,7 +316,8 @@ export class MemberService {
         }
 
         uniqueSubjects.set(key, {
-          userId: subject.subjectID || subject.userId || null,
+          userId:
+            subject.subjectID || subject.subjectId || subject.userId || null,
           handle: subject.handle || null,
           email,
         });
@@ -336,5 +334,91 @@ export class MemberService {
 
   async getRoleSubjectsByRoleName(roleName: string): Promise<MemberDetail[]> {
     return this.getRoleSubjects(roleName);
+  }
+
+  /**
+   * Extracts an array payload from Identity responses.
+   *
+   * @param payload Identity API response body in direct or legacy wrapped form.
+   * @returns Extracted array or an empty array when the shape is unsupported.
+   */
+  private extractArrayPayload<T>(payload: unknown): T[] {
+    if (Array.isArray(payload)) {
+      return payload as T[];
+    }
+
+    if (!payload || typeof payload !== 'object') {
+      return [];
+    }
+
+    const response = payload as {
+      content?: unknown;
+      result?: {
+        content?: unknown;
+      };
+    };
+
+    if (Array.isArray(response.result?.content)) {
+      return response.result.content as T[];
+    }
+
+    if (Array.isArray(response.content)) {
+      return response.content as T[];
+    }
+
+    return [];
+  }
+
+  /**
+   * Extracts role subjects from Identity role-detail responses.
+   *
+   * @param payload Identity role-detail body in direct, legacy wrapped, or list form.
+   * @returns Role subject records or an empty array when no subjects are present.
+   */
+  private extractRoleSubjects(payload: unknown): RoleSubjectRecord[] {
+    const directSubjects = this.extractSubjectsFromObject(payload);
+    if (directSubjects.length > 0) {
+      return directSubjects;
+    }
+
+    const listPayload = this.extractArrayPayload<RoleSubjectRecord>(payload);
+    if (listPayload.length > 0) {
+      return listPayload;
+    }
+
+    if (!payload || typeof payload !== 'object') {
+      return [];
+    }
+
+    const response = payload as {
+      content?: unknown;
+      result?: {
+        content?: unknown;
+      };
+    };
+
+    const resultSubjects = this.extractSubjectsFromObject(
+      response.result?.content,
+    );
+    if (resultSubjects.length > 0) {
+      return resultSubjects;
+    }
+
+    return this.extractSubjectsFromObject(response.content);
+  }
+
+  /**
+   * Extracts a `subjects` array from an object-like response fragment.
+   *
+   * @param payload Response fragment that may contain a `subjects` property.
+   * @returns Subjects array or an empty array when absent.
+   */
+  private extractSubjectsFromObject(payload: unknown): RoleSubjectRecord[] {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return [];
+    }
+
+    const subjects = (payload as { subjects?: unknown }).subjects;
+    return Array.isArray(subjects) ? (subjects as RoleSubjectRecord[]) : [];
   }
 }


### PR DESCRIPTION
What was broken
PM users could still be missed by copilot application emails when the Identity API returned role lists or role subjects in the legacy wrapped response shape.

Root cause
The PM recipient lookup only parsed direct array/direct subjects payloads and requested subjects with the newer selector parameter. Legacy Identity responses expose role data under result.content and role subjects under result.content.subjects, so the lookup could resolve no PM subjects and skip the notification.

What was changed
Updated MemberService role-subject parsing to support direct and legacy wrapped Identity responses, include the legacy fields=subjects expansion parameter, and accept subjectId as well as subjectID/userId when normalizing recipients.

Any added/updated tests
Added MemberService coverage for legacy wrapped Project Manager role and subject responses to verify PM recipients are still resolved for copilot application notifications.

Validation
- pnpm test -- src/shared/services/member.service.spec.ts src/api/copilot/copilot-notification.service.spec.ts passed.
- pnpm lint passed.
- pnpm build passed.
- pnpm test currently fails in pre-existing metadata event specs because metadata-event.utils.ts is a no-op while those specs expect publishProjectEvent to be called. The PM-2648 focused specs pass.
