### PR TITLE
PM-5485 - media assets for project showcase

### DIFF
--- a/prisma/migrations/20260624000000_add_project_showcase_cms/migration.sql
+++ b/prisma/migrations/20260624000000_add_project_showcase_cms/migration.sql
@@ -51,6 +51,17 @@ CREATE TABLE projects."project_showcase_post_categories" (
     UNIQUE ("projectShowcasePostId", "categoryId")
 );
 
+CREATE TABLE projects."project_showcase_post_media" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "projectShowcasePostId" BIGINT NOT NULL,
+  "type" VARCHAR(255) NOT NULL,
+  "url" VARCHAR(2048) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT now(),
+  "createdBy" BIGINT NOT NULL,
+  CONSTRAINT "project_showcase_post_media_project_showcase_post_fkey"
+    FOREIGN KEY ("projectShowcasePostId") REFERENCES projects."project_showcase_posts"("id") ON DELETE CASCADE
+);
+
 -- Indexes for query performance
 CREATE INDEX "project_showcase_posts_status_idx" ON projects."project_showcase_posts"("status");
 CREATE INDEX "project_showcase_posts_project_id_idx" ON projects."project_showcase_posts"("projectId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1075,6 +1075,7 @@ model ProjectShowcasePost {
   project        Project                   @relation(fields: [projectId], references: [id], onDelete: Cascade)
   industries     ProjectShowcasePostIndustry[]
   categories     ProjectShowcasePostCategory[]
+  media          ProjectShowcasePostMedia[]
 
   @@index([status])
   @@index([projectId])
@@ -1129,4 +1130,19 @@ model ProjectShowcasePostCategory {
   @@index([projectShowcasePostId])
   @@index([categoryId])
   @@map("project_showcase_post_categories")
+}
+
+/// Media assets attached to project showcase posts.
+model ProjectShowcasePostMedia {
+  id                    BigInt                    @id @default(autoincrement())
+  projectShowcasePostId BigInt
+  type                  String
+  url                   String
+  createdAt             DateTime                  @default(now())
+  createdBy             BigInt
+
+  projectShowcasePost    ProjectShowcasePost    @relation(fields: [projectShowcasePostId], references: [id], onDelete: Cascade)
+
+  @@index([projectShowcasePostId])
+  @@map("project_showcase_post_media")
 }

--- a/src/api/project-showcase-post/dto/create-project-showcase-post.dto.ts
+++ b/src/api/project-showcase-post/dto/create-project-showcase-post.dto.ts
@@ -1,6 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
 import { ProjectShowcasePostStatus } from '@prisma/client';
+import { ProjectShowcasePostMediaInputDto } from './project-showcase-post-media-input.dto';
 
 export class CreateProjectShowcasePostDto {
   @ApiProperty({ description: 'Post title.' })
@@ -35,4 +45,11 @@ export class CreateProjectShowcasePostDto {
   @IsArray()
   @IsUUID('4', { each: true })
   challengeIds?: string[];
+
+  @ApiPropertyOptional({ type: [Object] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ProjectShowcasePostMediaInputDto)
+  media?: ProjectShowcasePostMediaInputDto[];
 }

--- a/src/api/project-showcase-post/dto/create-project-showcase-post.dto.ts
+++ b/src/api/project-showcase-post/dto/create-project-showcase-post.dto.ts
@@ -46,7 +46,7 @@ export class CreateProjectShowcasePostDto {
   @IsUUID('4', { each: true })
   challengeIds?: string[];
 
-  @ApiPropertyOptional({ type: [Object] })
+  @ApiPropertyOptional({ type: [ProjectShowcasePostMediaInputDto] })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/api/project-showcase-post/dto/project-showcase-post-media-input.dto.ts
+++ b/src/api/project-showcase-post/dto/project-showcase-post-media-input.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+
+export class ProjectShowcasePostMediaInputDto {
+  @ApiProperty({ description: 'MIME type of the media asset.' })
+  @IsString()
+  @IsNotEmpty()
+  type: string;
+
+  @ApiProperty({ description: 'URL of the media asset.' })
+  @IsUrl()
+  url: string;
+}

--- a/src/api/project-showcase-post/dto/project-showcase-post-media.dto.ts
+++ b/src/api/project-showcase-post/dto/project-showcase-post-media.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+
+export class ProjectShowcasePostMediaDto {
+  @ApiProperty({ description: 'Media asset id.' })
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty({ description: 'MIME type of the media asset.' })
+  @IsString()
+  @IsNotEmpty()
+  type: string;
+
+  @ApiProperty({ description: 'URL of the media asset.' })
+  @IsUrl()
+  url: string;
+
+  @ApiProperty({ description: 'Timestamp when media asset was created.' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'User id who created the media asset.' })
+  createdBy: string;
+}

--- a/src/api/project-showcase-post/dto/project-showcase-post-response.dto.ts
+++ b/src/api/project-showcase-post/dto/project-showcase-post-response.dto.ts
@@ -1,5 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ProjectShowcasePostStatus } from '@prisma/client';
+import { ProjectShowcasePostMediaDto } from './project-showcase-post-media.dto';
 
 export class ProjectShowcasePostResponseDto {
   @ApiProperty()
@@ -25,6 +26,9 @@ export class ProjectShowcasePostResponseDto {
 
   @ApiProperty({ type: [Object] })
   categories: Array<{ id: string; name: string }>;
+
+  @ApiPropertyOptional({ type: [ProjectShowcasePostMediaDto] })
+  media?: ProjectShowcasePostMediaDto[];
 
   @ApiProperty()
   createdById: number;

--- a/src/api/project-showcase-post/project-showcase-post.service.spec.ts
+++ b/src/api/project-showcase-post/project-showcase-post.service.spec.ts
@@ -55,6 +55,15 @@ describe('ProjectShowcasePostService', () => {
           },
         },
       ],
+      media: [
+        {
+          id: BigInt(101),
+          type: 'image/png',
+          url: 'https://example.com/image.png',
+          createdAt: new Date('2026-01-01T00:00:00Z'),
+          createdBy: BigInt(42),
+        },
+      ],
       ...overrides,
     } as const;
   }
@@ -188,10 +197,70 @@ describe('ProjectShowcasePostService', () => {
           categories: {
             create: [{ categoryId: BigInt(7) }],
           },
+          media: {
+            create: [],
+          },
         }),
       }),
     );
     expect(response.status).toBe('DRAFT');
+  });
+
+  it('creates a new project showcase post with media assets', async () => {
+    prismaMock.projectShowcasePost.create.mockResolvedValue(
+      buildPostRecord({
+        status: 'DRAFT',
+        media: [
+          {
+            id: BigInt(101),
+            type: 'image/png',
+            url: 'https://example.com/image.png',
+            createdAt: new Date('2026-01-01T00:00:00Z'),
+            createdBy: BigInt(42),
+          },
+        ],
+      }),
+    );
+
+    const response = await service.createPost(
+      '1001',
+      {
+        title: 'New post',
+        content: 'New content',
+        industryIds: ['5'],
+        categoryIds: ['7'],
+        media: [
+          {
+            type: 'image/png',
+            url: 'https://example.com/image.png',
+          },
+        ],
+      },
+      user,
+    );
+
+    expect(prismaMock.projectShowcasePost.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          media: {
+            create: [
+              {
+                type: 'image/png',
+                url: 'https://example.com/image.png',
+                createdBy: 42,
+              },
+            ],
+          },
+        }),
+      }),
+    );
+    expect(response.media).toEqual([
+      expect.objectContaining({
+        id: '101',
+        type: 'image/png',
+        url: 'https://example.com/image.png',
+      }),
+    ]);
   });
 
   it('throws NotFoundException when create hits an industry foreign key constraint', async () => {
@@ -298,6 +367,66 @@ describe('ProjectShowcasePostService', () => {
       }),
     );
     expect(response.title).toBe('Updated title');
+  });
+
+  it('updates a post with media assets', async () => {
+    prismaMock.projectShowcasePost.findFirst.mockResolvedValue(
+      buildPostRecord(),
+    );
+    prismaMock.projectShowcasePost.update.mockResolvedValue(
+      buildPostRecord({
+        title: 'Updated title',
+        media: [
+          {
+            id: BigInt(102),
+            type: 'video/mp4',
+            url: 'https://example.com/video.mp4',
+            createdAt: new Date('2026-01-01T00:00:00Z'),
+            createdBy: BigInt(42),
+          },
+        ],
+      }),
+    );
+
+    const response = await service.updatePost(
+      '1001',
+      '10',
+      {
+        title: 'Updated title',
+        media: [
+          {
+            type: 'video/mp4',
+            url: 'https://example.com/video.mp4',
+          },
+        ],
+      },
+      user,
+    );
+
+    expect(prismaMock.projectShowcasePost.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: BigInt(10) },
+        data: expect.objectContaining({
+          media: {
+            deleteMany: {},
+            create: [
+              {
+                type: 'video/mp4',
+                url: 'https://example.com/video.mp4',
+                createdBy: 42,
+              },
+            ],
+          },
+        }),
+      }),
+    );
+    expect(response.media).toEqual([
+      expect.objectContaining({
+        id: '102',
+        type: 'video/mp4',
+        url: 'https://example.com/video.mp4',
+      }),
+    ]);
   });
 
   it('throws NotFoundException when update hits an industry foreign key constraint', async () => {

--- a/src/api/project-showcase-post/project-showcase-post.service.ts
+++ b/src/api/project-showcase-post/project-showcase-post.service.ts
@@ -211,7 +211,7 @@ export class ProjectShowcasePostService {
             create: (dto.media || []).map((asset) => ({
               type: asset.type,
               url: asset.url,
-              createdBy: auditUserId,
+              createdBy: BigInt(auditUserId),
             })),
           },
         },
@@ -297,13 +297,14 @@ export class ProjectShowcasePostService {
       };
     }
 
-    if (typeof dto.media !== 'undefined') {
+    if (typeof dto.media !== 'undefined' && Array.isArray(dto.media)) {
+      const auditUserId = BigInt(getAuditUserId(user));
       updateData.media = {
         deleteMany: {},
         create: dto.media.map((mediaItem) => ({
           type: mediaItem.type,
           url: mediaItem.url,
-          createdBy: getAuditUserId(user),
+          createdBy: auditUserId,
         })),
       };
     }
@@ -458,7 +459,13 @@ export class ProjectShowcasePostService {
     post: ProjectShowcasePost & {
       industries: { industry: { id: bigint; name: string } }[];
       categories: { category: { id: bigint; name: string } }[];
-      media: { id: bigint; type: string; url: string; createdAt: Date; createdBy: bigint }[];
+      media: {
+        id: bigint;
+        type: string;
+        url: string;
+        createdAt: Date;
+        createdBy: bigint;
+      }[];
     },
   ): ProjectShowcasePostResponseDto {
     return {

--- a/src/api/project-showcase-post/project-showcase-post.service.ts
+++ b/src/api/project-showcase-post/project-showcase-post.service.ts
@@ -44,6 +44,7 @@ export class ProjectShowcasePostService {
         categories: {
           include: { category: true },
         },
+        media: true,
       },
       orderBy,
       skip,
@@ -90,6 +91,7 @@ export class ProjectShowcasePostService {
         categories: {
           include: { category: true },
         },
+        media: true,
       },
       orderBy,
       skip,
@@ -151,6 +153,7 @@ export class ProjectShowcasePostService {
         categories: {
           include: { category: true },
         },
+        media: true,
       },
     });
 
@@ -204,6 +207,13 @@ export class ProjectShowcasePostService {
           categories: {
             create: categoryIds.map((categoryId) => ({ categoryId })),
           },
+          media: {
+            create: (dto.media || []).map((asset) => ({
+              type: asset.type,
+              url: asset.url,
+              createdBy: auditUserId,
+            })),
+          },
         },
         include: {
           industries: {
@@ -212,6 +222,7 @@ export class ProjectShowcasePostService {
           categories: {
             include: { category: true },
           },
+          media: true,
         },
       });
 
@@ -286,6 +297,17 @@ export class ProjectShowcasePostService {
       };
     }
 
+    if (typeof dto.media !== 'undefined') {
+      updateData.media = {
+        deleteMany: {},
+        create: dto.media.map((mediaItem) => ({
+          type: mediaItem.type,
+          url: mediaItem.url,
+          createdBy: getAuditUserId(user),
+        })),
+      };
+    }
+
     try {
       const updated = await this.prisma.projectShowcasePost.update({
         where: {
@@ -299,6 +321,7 @@ export class ProjectShowcasePostService {
           categories: {
             include: { category: true },
           },
+          media: true,
         },
       });
 
@@ -435,6 +458,7 @@ export class ProjectShowcasePostService {
     post: ProjectShowcasePost & {
       industries: { industry: { id: bigint; name: string } }[];
       categories: { category: { id: bigint; name: string } }[];
+      media: { id: bigint; type: string; url: string; createdAt: Date; createdBy: bigint }[];
     },
   ): ProjectShowcasePostResponseDto {
     return {
@@ -455,6 +479,13 @@ export class ProjectShowcasePostService {
       categories: post.categories.map((entry) => ({
         id: String(entry.category.id),
         name: entry.category.name,
+      })),
+      media: post.media.map((entry) => ({
+        id: String(entry.id),
+        type: entry.type,
+        url: entry.url,
+        createdAt: entry.createdAt,
+        createdBy: String(entry.createdBy),
       })),
     };
   }


### PR DESCRIPTION
This pull request adds support for attaching media assets (such as images and videos) to project showcase posts. It introduces the necessary database schema, DTOs, service logic, and tests to enable creating, updating, and retrieving media assets associated with posts.

**Database and Schema Changes**
- Added a new table `project_showcase_post_media` to store media assets linked to showcase posts, including fields for type, URL, creator, and timestamps.
- Updated the Prisma schema to include the `ProjectShowcasePostMedia` model and relate it to `ProjectShowcasePost`. 

**DTO and API Changes**
- Introduced `ProjectShowcasePostMediaInputDto` and `ProjectShowcasePostMediaDto` for input and output of media assets, and extended the create/update/showcase post DTOs to include a `media` field.

**Service Logic**
- Updated `ProjectShowcasePostService` to handle creation, updating, and retrieval of media assets as part of project showcase posts. Media assets are now created, updated (with full replacement), and returned in API responses. 

**Testing**
- Added and extended tests to verify creating and updating posts with media assets, ensuring correct persistence and API response structure.